### PR TITLE
order dt by id before extracting values

### DIFF
--- a/R/winderodibility.R
+++ b/R/winderodibility.R
@@ -50,6 +50,7 @@ calc_winderodibility <- function(A_CLAY_MI,A_SILT_MI,B_LU_BRP) {
   dt[, value := pmax(pmin(value, 1), 0)]
   
   # return Wind Erodibility Factor
+  setorder(dt, id)
   value <- dt[, value]
   
   # return


### PR DESCRIPTION
The dt was orderd by id before extracting the values. 
In the previous version, the order of dt was distorted after the merge function and not re-ordered, and therefore returning wrong values of D_P_DU.