### PR TITLE
correct maximum scores in ind_management() function description

### DIFF
--- a/R/management.R
+++ b/R/management.R
@@ -270,8 +270,8 @@ calc_management <- function(A_SOM_LOI,B_LU_BRP, B_SOILTYPE_AGR,B_GWL_CLASS,
 #' This function calculates the the sustainability of strategic management options as calculated by \code{\link{calc_management}}
 #' The main source of this indicator is developed for Label Duurzaam Bodembeheer (Van der Wal, 2016)
 #' 
-#' The current function allows a maximum score of 16 points for arable systems, 12 for maize 
-#' and 9 for grass (non-peat) and 17 for grass on peat. 
+#' The current function allows a maximum score of 18 points for arable systems, 12 for maize 
+#' and 10 for grass (non-peat), 17 for grass on peat, and 4 for nature. 
 #' 
 #' @param D_MAN (numeric) The value of Sustainable Management  calculated by \code{\link{calc_management}}
 #' @param B_LU_BRP (numeric) The crop code (gewascode) from the BRP


### PR DESCRIPTION
Maximum values given for arable and grass systems were different in the functions description compared to the table used within the function. Additionally, "natuur" was missing from the function description.
![afbeelding](https://user-images.githubusercontent.com/72964508/116559255-874d0d00-a900-11eb-8491-08a200d54e38.png)
