### PR TITLE
Release/v3.0.2 cran

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 ## Changed
 * `B_LU_WATERSTRESS_OBIC` of 265 (grasland blijvend), 331, and 3718 from 'grasland met herinzaai' to 'grasland zonder herinzaai' in `crops.obic`
 
+## Removed
+* Removes urls to bodemconsult.nl due to invalid SSL certificate, which is not accepted by CRAN
+
 # OBIC 3.0.1 2023-11-24
 ## Fixed
 * Fixes calculation of N surplus used for I_H_NGW and I_H_NSW

--- a/vignettes/vignettes_references.bib
+++ b/vignettes/vignettes_references.bib
@@ -56,7 +56,6 @@ author = {Huinink, J.Th.M.},
 institution = {BodemConsult-Arnhem},
 pages = {104},
 title = {{Bodem/perceel geschiktheidsbeoordeling voor Landbouw, Bosbouw en Recreatie: t.b.v. een optimalisatie van grondwater- en oppervlaktewaterpeilbeheer: state of the art 2018}},
-url = {www.bodemconsult.nl},
 year = {2018}
 }
 @book{Locher1990,

--- a/vignettes/workability_references.bib
+++ b/vignettes/workability_references.bib
@@ -4,6 +4,5 @@ file = {:C\:/Users/Brent Riechelman/Documents/Projecten/OBIC/OBIC functies bodem
 institution = {BodemConsult-Arnhem},
 pages = {104},
 title = {{Bodem/perceel geschiktheidsbeoordeling voor Landbouw, Bosbouw en Recreatie: t.b.v. een optimalisatie van grondwater- en oppervlaktewaterpeilbeheer: state of the art 2018}},
-url = {www.bodemconsult.nl},
 year = {2018}
 }


### PR DESCRIPTION
### Removed

* Removes urls to bodemconsult.nl due to invalid SSL certificate, which is not accepted by CRAN
